### PR TITLE
Add protocols to CFRoutes info

### DIFF
--- a/cfroutes/routing_info_helpers.go
+++ b/cfroutes/routing_info_helpers.go
@@ -15,6 +15,7 @@ type CFRoute struct {
 	Port             uint32   `json:"port"`
 	RouteServiceUrl  string   `json:"route_service_url,omitempty"`
 	IsolationSegment string   `json:"isolation_segment,omitempty"`
+	Protocol         string   `json:"protocol,omitempty"`
 }
 
 func (c CFRoutes) RoutingInfo() models.Routes {

--- a/cfroutes/routing_info_helpers_test.go
+++ b/cfroutes/routing_info_helpers_test.go
@@ -32,6 +32,7 @@ var _ = Describe("RoutingInfoHelpers", func() {
 			Hostnames:       []string{"foo3.example.com", "bar3.examaple.com"},
 			Port:            33333,
 			RouteServiceUrl: "rs.example.com",
+			Protocol:        "http2",
 		}
 
 		routes = cfroutes.CFRoutes{route1, route2, route3}


### PR DESCRIPTION
This is to support HTTP/2 traffic in route-emitter. See
[this issue](https://github.com/cloudfoundry/routing-release/issues/200) for more
details.

Co-authored-by: Weyman Fung <weymanf@vmware.com>