### PR TITLE
feat: Implement per-route options forwarding in route-emitter

### DIFF
--- a/cfroutes/routing_info_helpers.go
+++ b/cfroutes/routing_info_helpers.go
@@ -11,11 +11,12 @@ const CF_ROUTER = "cf-router"
 type CFRoutes []CFRoute
 
 type CFRoute struct {
-	Hostnames        []string `json:"hostnames"`
-	Port             uint32   `json:"port"`
-	RouteServiceUrl  string   `json:"route_service_url,omitempty"`
-	IsolationSegment string   `json:"isolation_segment,omitempty"`
-	Protocol         string   `json:"protocol,omitempty"`
+	Hostnames        []string        `json:"hostnames"`
+	Port             uint32          `json:"port"`
+	RouteServiceUrl  string          `json:"route_service_url,omitempty"`
+	IsolationSegment string          `json:"isolation_segment,omitempty"`
+	Protocol         string          `json:"protocol,omitempty"`
+	Options          json.RawMessage `json:"options,omitempty"`
 }
 
 func (c CFRoutes) RoutingInfo() models.Routes {

--- a/cfroutes/routing_info_helpers_test.go
+++ b/cfroutes/routing_info_helpers_test.go
@@ -15,6 +15,7 @@ var _ = Describe("RoutingInfoHelpers", func() {
 		route1 cfroutes.CFRoute
 		route2 cfroutes.CFRoute
 		route3 cfroutes.CFRoute
+		route4 cfroutes.CFRoute
 
 		routes cfroutes.CFRoutes
 	)
@@ -34,8 +35,13 @@ var _ = Describe("RoutingInfoHelpers", func() {
 			RouteServiceUrl: "rs.example.com",
 			Protocol:        "http2",
 		}
+		route4 = cfroutes.CFRoute{
+			Hostnames: []string{"foo4.example.com", "bar4.examaple.com"},
+			Port:      44444,
+			Options:   json.RawMessage(`{"lb_algo":"least-connection"}`),
+		}
 
-		routes = cfroutes.CFRoutes{route1, route2, route3}
+		routes = cfroutes.CFRoutes{route1, route2, route3, route4}
 	})
 
 	Describe("RoutingInfo", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
* Part of [RFC 0027 - Generic Per-Route Features](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md) ([Tracking issue](https://github.com/cloudfoundry/community/issues/909))
* Required for `route-emitter` to forward the route-specific`Options` field ([Tracking issue](https://github.com/cloudfoundry/diego-release/issues/940))
* Companion PR: https://github.com/cloudfoundry/route-emitter/pull/47


Backward Compatibility
---------------
Breaking Change? **No**

