### PR TITLE
refactor: rename lb_algo to loadbalancing

### DIFF
--- a/cfroutes/routing_info_helpers_test.go
+++ b/cfroutes/routing_info_helpers_test.go
@@ -38,7 +38,7 @@ var _ = Describe("RoutingInfoHelpers", func() {
 		route4 = cfroutes.CFRoute{
 			Hostnames: []string{"foo4.example.com", "bar4.examaple.com"},
 			Port:      44444,
-			Options:   json.RawMessage(`{"lb_algo":"least-connection"}`),
+			Options:   json.RawMessage(`{"loadbalancing":"least-connection"}`),
 		}
 
 		routes = cfroutes.CFRoutes{route1, route2, route3, route4}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Renaming the `lb_algo` property to `loadbalancing` to align with cloud controller.
The per-route options feature ([RFC 0027](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)) is not live yet, so this is not a breaking change.
See https://github.com/cloudfoundry/community/pull/1039 for an overview of all related PRs


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
