### PR TITLE
Use golang/protobuf instead of gogo/protobuf

### DIFF
--- a/internalroutes/routing_info_helpers.go
+++ b/internalroutes/routing_info_helpers.go
@@ -41,12 +41,12 @@ func (r InternalRoutes) Equal(o InternalRoutes) bool {
 	return true
 }
 
-func InternalRoutesFromRoutingInfo(routingInfo models.Routes) (InternalRoutes, error) {
+func InternalRoutesFromRoutingInfo(routingInfo *models.Routes) (InternalRoutes, error) {
 	if routingInfo == nil {
 		return nil, nil
 	}
 
-	routes := routingInfo
+	routes := *routingInfo
 	data, found := routes[INTERNAL_ROUTER]
 	if !found {
 		return nil, nil

--- a/internalroutes/routing_info_helpers_test.go
+++ b/internalroutes/routing_info_helpers_test.go
@@ -105,7 +105,7 @@ var _ = Describe("RoutingInfoHelpers", func() {
 		)
 
 		JustBeforeEach(func() {
-			routesResult, conversionError = internalroutes.InternalRoutesFromRoutingInfo(routingInfo)
+			routesResult, conversionError = internalroutes.InternalRoutesFromRoutingInfo(&routingInfo)
 		})
 
 		Context("when internal routes are present in the routing info", func() {


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[gogo/protobuf](https://github.com/gogo/protobuf) has been deprecated for years.  We should be using up-to-date protobufs provided by [google.golang.org/protobuf](https://github.com/protocolbuffers/protobuf-go).  In order to fit our use cases, a protobuf plugin (`protoc-gen-go-bbs`) has been created to catch any customizations we want to add.


Backward Compatibility
---------------
Breaking Change? **No**
