### PR TITLE
sni based routing for tcp apps

### DIFF
--- a/tcp_routes/routes_helper.go
+++ b/tcp_routes/routes_helper.go
@@ -11,9 +11,11 @@ const TCP_ROUTER = "tcp-router"
 type TCPRoutes []TCPRoute
 
 type TCPRoute struct {
-	RouterGroupGuid string `json:"router_group_guid"`
-	ExternalPort    uint32 `json:"external_port"`
-	ContainerPort   uint32 `json:"container_port"`
+	RouterGroupGuid      string  `json:"router_group_guid"`
+	ExternalPort         uint32  `json:"external_port"`
+	ContainerPort        uint32  `json:"container_port"`
+	SniHostname          *string `json:"backend_sni_hostname,omitempty"`
+	TerminateFrontendTLS bool    `json:"terminate_frontend_tls,omitempty"`
 }
 
 func (c TCPRoutes) RoutingInfo() *models.Routes {

--- a/tcp_routes/tcp_routes_test.go
+++ b/tcp_routes/tcp_routes_test.go
@@ -95,6 +95,23 @@ var _ = Describe("TcpRoutes", func() {
 				Expect(routesResult).To(Equal(routes))
 			})
 
+			Context("when backend SNI and terminate_frontend_tls are set", func() {
+				BeforeEach(func() {
+					sniHostname := "sni-hostname"
+					route1.SniHostname = &sniHostname
+					route1.TerminateFrontendTLS = true
+					routes = tcp_routes.TCPRoutes{route1}
+					routingInfo = routes.RoutingInfo()
+				})
+
+				It("correctly round-trips the SNI fields", func() {
+					Expect(conversionError).NotTo(HaveOccurred())
+					Expect(routesResult).To(Equal(routes))
+					Expect(*routesResult[0].SniHostname).To(Equal("sni-hostname"))
+					Expect(routesResult[0].TerminateFrontendTLS).To(BeTrue())
+				})
+			})
+
 			Context("when the TCP routes are nil", func() {
 				BeforeEach(func() {
 					routingInfo = &models.Routes{tcp_routes.TCP_ROUTER: nil}


### PR DESCRIPTION
ai-assisted=yes
TNZ-81099

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
